### PR TITLE
Add Prism to Bower dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,7 @@
     "jquery": "~2.1.1",
     "snapjs": "~1.9.3",
     "responsive-elements": "~1.0.0",
-    "gridforms": "~1.0.2"
+    "gridforms": "~1.0.2",
+    "prism": "gh-pages"
   }
 }


### PR DESCRIPTION
Prism was references in example, but not downloaded by Bower.
