### PR TITLE
Make package name Bower spec-compliant

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "Flakes Framework",
+  "name": "flakes",
   "version": "0.0.1",
   "dependencies": {
     "jquery": "~2.1.1",


### PR DESCRIPTION
As mentioned in #3, the framework should be available via Bower. Changing the package name to 'flakes' instead of 'Flakes Framwork' will make it easier to install once it's registered with Bower.
