### PR TITLE
Removing reference to Prism stylesheet

### DIFF
--- a/example.html
+++ b/example.html
@@ -247,7 +247,6 @@
 	</div>
 
 
-	<link rel="stylesheet" type="text/css" href="bower_components/prism/themes/prism.css">
 	<link rel="stylesheet" type="text/css" href="bower_components/gridforms/gridforms/gridforms.css">
 
 	<script src="bower_components/jquery/dist/jquery.js"></script>


### PR DESCRIPTION
The bower configuration doesn't include Prism, so this file will 404. Since the example page doesn't utilize syntax highlighting, I'm removing it.
