### PR TITLE
Adding Prism to Bower config

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,7 @@
     "jquery": "~2.1.1",
     "snapjs": "~1.9.3",
     "responsive-elements": "~1.0.0",
-    "gridforms": "~1.0.2"
+    "gridforms": "~1.0.2",
+    "prism": "gh-pages"
   }
 }


### PR DESCRIPTION
Flakes uses Prism for syntax highlighting, but it wasn’t included inthe Bower config. Because Prism doesn’t have a master branch for Bower to use (LeaVerou/prism#180), this references the active branch.
