### PR TITLE
Support Browserify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 
+/node_modules
 bower_components
 
 #############

--- a/js/base.js
+++ b/js/base.js
@@ -1,4 +1,13 @@
-
+(function (root, factory) {
+	if (typeof module === 'object' && module.exports) {
+		module.exports = factory;
+	} else {
+		root.FlakesFrame = factory(root.jQuery, root.Snap);
+		root.jQuery(function () {
+			root.FlakesFrame.init();
+		});
+	}
+}(this, function ($, Snap) {
 var ie_version = function() {
 	// ----------------------------------------------------------
 	// A short snippet for detecting versions of IE in JavaScript
@@ -91,7 +100,5 @@ var FlakesFrame = {
 	}
 };
 
-// Initialize modules when DOM is ready
-jQuery(function() {
-	FlakesFrame.init();
-});
+return FlakesFrame;
+}));


### PR DESCRIPTION
I've been looking at using this theme for an internal tool I'm building, but I'm mostly using a npm + Browserify based setup nowadays and this module currently doesn't play that well with that so wanted to open an issue/PR to start looking at supporting a Browserify + npm based approach in addition to the current Bower one.

This extends on #32, but it doesn't include any dependencies because eg. the Snap.js library isn't officially available as an npm dependency and neither are your own dependencies so leaving it up to the consumer to ensure that jQuery and Snap.js is available for the module.
